### PR TITLE
fix(netfilter): требовать свободность и mark, и table при выделении индекса

### DIFF
--- a/src/backend/utils/netfilterTools/ipset-to-link.go
+++ b/src/backend/utils/netfilterTools/ipset-to-link.go
@@ -367,10 +367,9 @@ func (r *IPSetToLink) getUnusedMarkAndTable() (idx uint32, err error) {
 	}
 
 	for idx = r.startIdx; idx < 0x7ffffffe; idx++ {
-		if _, exists := tableMap[int(idx)]; !exists {
-			break
-		}
-		if _, exists := markMap[idx]; !exists {
+		_, tableExists := tableMap[int(idx)]
+		_, markExists := markMap[idx]
+		if !tableExists && !markExists {
 			break
 		}
 	}


### PR DESCRIPTION
## Проблема

`getUnusedMarkAndTable()` проверяет `tableMap` и `markMap` независимо — цикл прерывается, когда **любой** из двух ресурсов свободен, что может привести к выделению индекса, уже занятого вторым ресурсом.

```go
if _, exists := tableMap[int(idx)]; !exists {
    break
}
if _, exists := markMap[idx]; !exists {
    break
}
```

Если `tableMap` содержит `idx`, но `markMap` — нет, первая проверка проходит (exists=true, break не срабатывает), а вторая прерывает цикл, возвращая индекс с **уже занятой таблицей маршрутизации**.

## Исправление

Проверка обоих условий одновременно — цикл прерывается только когда индекс свободен в обеих картах:

```go
_, tableExists := tableMap[int(idx)]
_, markExists := markMap[idx]
if !tableExists && !markExists {
    break
}
```

## Последствия без фикса

При одновременном включении нескольких групп возможна коллизия таблиц маршрутизации, что приводит к маршрутизации трафика через неправильный интерфейс.